### PR TITLE
Copy to clipboard utility function

### DIFF
--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -6,7 +6,7 @@ declare module Utils {
 declare module Utils {
     class Clipboard {
         static Copy(text: string): void;
-        static BrowserSupportsCopy(): boolean;
+        static SupportsCopy(): boolean;
     }
 }
 /**

--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -1,6 +1,13 @@
+/// <reference path="typings/jquery.d.ts" />
 declare module Utils {
     class Bools {
         static GetBool(val: any, defaultVal: boolean): boolean;
+    }
+}
+declare module Utils {
+    class Clipboard {
+        static Copy(elem: HTMLElement): void;
+        static SupportsCopy(): boolean;
     }
 }
 /**

--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -5,8 +5,8 @@ declare module Utils {
 }
 declare module Utils {
     class Clipboard {
-        static Copy(elem: HTMLElement): void;
-        static SupportsCopy(): boolean;
+        static Copy(text: string): void;
+        static BrowserSupportsCopy(): boolean;
     }
 }
 /**

--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="typings/jquery.d.ts" />
 declare module Utils {
     class Bools {
         static GetBool(val: any, defaultVal: boolean): boolean;

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -26,7 +26,7 @@ var Utils;
             $temp.remove();
         };
         Clipboard.BrowserSupportsCopy = function () {
-            return (!(document.queryCommandSupported && document.queryCommandSupported('copy')));
+            return document.queryCommandSupported && document.queryCommandSupported('copy');
         };
         return Clipboard;
     })();

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -19,11 +19,16 @@ var Utils;
         function Clipboard() {
         }
         Clipboard.Copy = function (text) {
-            var $temp = $("<input>");
-            $("body").append($temp);
-            $temp.val(text).select();
+            var $tempDiv = $("<div>");
+            var brRegex = /<br\s*[\/]?>/gi;
+            text = text.replace(brRegex, "\n");
+            $("body").append($tempDiv);
+            $tempDiv.append(text);
+            var $tempInput = $("<textarea>");
+            $tempDiv.append($tempInput);
+            $tempInput.val($tempDiv.text()).select();
             document.execCommand("copy");
-            $temp.remove();
+            $tempDiv.remove();
         };
         Clipboard.SupportsCopy = function () {
             return document.queryCommandSupported && document.queryCommandSupported('copy');

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -13,6 +13,26 @@ var Utils;
     })();
     Utils.Bools = Bools;
 })(Utils || (Utils = {}));
+/// <reference path="../typings/jquery.d.ts" />
+var Utils;
+(function (Utils) {
+    var Clipboard = (function () {
+        function Clipboard() {
+        }
+        Clipboard.Copy = function (elem) {
+            var $temp = $("<input>");
+            $("body").append($temp);
+            $temp.val($(elem).text()).select();
+            document.execCommand("copy");
+            $temp.remove();
+        };
+        Clipboard.SupportsCopy = function () {
+            return true;
+        };
+        return Clipboard;
+    })();
+    Utils.Clipboard = Clipboard;
+})(Utils || (Utils = {}));
 // Copyright 2013 Basarat Ali Syed. All Rights Reserved.
 //
 // Licensed under MIT open source license http://opensource.org/licenses/MIT

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -13,7 +13,6 @@ var Utils;
     })();
     Utils.Bools = Bools;
 })(Utils || (Utils = {}));
-/// <reference path="../typings/jquery.d.ts" />
 var Utils;
 (function (Utils) {
     var Clipboard = (function () {

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -18,15 +18,15 @@ var Utils;
     var Clipboard = (function () {
         function Clipboard() {
         }
-        Clipboard.Copy = function (elem) {
+        Clipboard.Copy = function (text) {
             var $temp = $("<input>");
             $("body").append($temp);
-            $temp.val($(elem).text()).select();
+            $temp.val(text).select();
             document.execCommand("copy");
             $temp.remove();
         };
-        Clipboard.SupportsCopy = function () {
-            return true;
+        Clipboard.BrowserSupportsCopy = function () {
+            return (!(document.queryCommandSupported && document.queryCommandSupported('copy')));
         };
         return Clipboard;
     })();

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -19,7 +19,7 @@ var Utils;
         function Clipboard() {
         }
         Clipboard.Copy = function (text) {
-            var $tempDiv = $("<div>");
+            var $tempDiv = $("<div style='position:absolute;left:-9999px'>");
             var brRegex = /<br\s*[\/]?>/gi;
             text = text.replace(brRegex, "\n");
             $("body").append($tempDiv);

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -25,7 +25,7 @@ var Utils;
             document.execCommand("copy");
             $temp.remove();
         };
-        Clipboard.BrowserSupportsCopy = function () {
+        Clipboard.SupportsCopy = function () {
             return document.queryCommandSupported && document.queryCommandSupported('copy');
         };
         return Clipboard;

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -1,0 +1,19 @@
+/// <reference path="../typings/jquery.d.ts" />
+module Utils {
+
+    export class Clipboard {
+        public static Copy(elem: HTMLElement) {
+            var $temp = $("<input>");
+            $("body").append($temp);
+            $temp.val($(elem).text()).select();
+            document.execCommand("copy");
+            $temp.remove();
+        }
+        
+        public static SupportsCopy(): boolean {
+            return true;
+        }
+        
+    }
+
+}

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -1,6 +1,4 @@
-/// <reference path="../typings/jquery.d.ts" />
 module Utils {
-
     export class Clipboard {
         public static Copy(elem: HTMLElement) {
             var $temp = $("<input>");

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -1,7 +1,7 @@
 module Utils {
     export class Clipboard {
         public static Copy(text: string) {
-            var $tempDiv = $("<div>");
+            var $tempDiv = $("<div style='position:absolute;left:-9999px'>");
             var brRegex = /<br\s*[\/]?>/gi;            
             text = text.replace(brRegex, "\n");
             $("body").append($tempDiv);

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -1,15 +1,15 @@
 module Utils {
     export class Clipboard {
-        public static Copy(elem: HTMLElement) {
+        public static Copy(text: string) {
             var $temp = $("<input>");
             $("body").append($temp);
-            $temp.val($(elem).text()).select();
+            $temp.val(text).select();
             document.execCommand("copy");
             $temp.remove();
         }
         
-        public static SupportsCopy(): boolean {
-            return true;
+        public static BrowserSupportsCopy(): boolean {
+            return (!(document.queryCommandSupported && document.queryCommandSupported('copy')));
         }
         
     }

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -8,7 +8,7 @@ module Utils {
             $temp.remove();
         }
         
-        public static BrowserSupportsCopy(): boolean {
+        public static SupportsCopy(): boolean {
             return document.queryCommandSupported && document.queryCommandSupported('copy');
         }
         

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -1,11 +1,16 @@
 module Utils {
     export class Clipboard {
         public static Copy(text: string) {
-            var $temp = $("<input>");
-            $("body").append($temp);
-            $temp.val(text).select();
+            var $tempDiv = $("<div>");
+            var brRegex = /<br\s*[\/]?>/gi;            
+            text = text.replace(brRegex, "\n");
+            $("body").append($tempDiv);
+            $tempDiv.append(text);
+            var $tempInput = $("<textarea>");
+            $tempDiv.append($tempInput);
+            $tempInput.val($tempDiv.text()).select();
             document.execCommand("copy");
-            $temp.remove();
+            $tempDiv.remove();
         }
         
         public static SupportsCopy(): boolean {

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -9,7 +9,7 @@ module Utils {
         }
         
         public static BrowserSupportsCopy(): boolean {
-            return (!(document.queryCommandSupported && document.queryCommandSupported('copy')));
+            return document.queryCommandSupported && document.queryCommandSupported('copy');
         }
         
     }


### PR DESCRIPTION
Utility function for copying text to the clipboard. No Flash-fallback. This will only work in browsers that support document.execCommand("copy"). This should be ok, because:
a) most browsers do
b) it is still entirely possible to select and copy text