### PR TITLE
Fix bug: when ratio1 == ratio2, returns [0, 0]

### DIFF
--- a/src/Measurements.ts
+++ b/src/Measurements.ts
@@ -17,8 +17,7 @@ namespace Utils.Measurements {
                 scale = width2 / width1;
                 width = width1 * scale;
                 height = height1 * scale;
-            }
-            if (ratio2 < ratio1) {
+            } else {
                 scale = height2 / height1;
                 width = width1 * scale;
                 height = height1 * scale;


### PR DESCRIPTION
I'm not sure why the code had separate `if (ratio1 < ratio2)` / `if (ratio2 < ratio1)` checks rather than a single if..else, but this seems cleaner and also eliminates an edge-case bug.