### PR TITLE
Strings.format: add named templates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -513,8 +513,20 @@ export class Strings {
         return <string>(<Node>div.firstChild).nodeValue;
     }
     
-    static format(str: string, ...values: string[]): string {
-        for (let i = 0; i < values.length; i++) {
+    static format(str: string, objOrStr: string | Record<string,string>, ...values: string[]): string {
+        // Named template
+        if (Object(objOrStr) === objOrStr) {
+            for (const key in (objOrStr as Record<string, string>)) {
+                const reg = new RegExp(`\\{${key}\\}`, "gm");
+                str = str.replace(reg, values[key]);
+            }
+
+            return str;
+        }
+
+        // Indexed template
+        values.unshift(objOrStr as string);
+        for (let i = 0; i < (values as string[]).length; i++) {
             const reg = new RegExp("\\{" + i + "\\}", "gm");
             str = str.replace(reg, values[i]);
         }

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,12 @@ describe("string", () => {
         expect(str === "Hi! My name is Slim Shady");
     });
 
+    it("formats (obj)", () => {
+        let str = "{greeting} My name is {alias}";
+        str = utils.Strings.format(str, { alias: "Slim Shady", greeting: "Hi!" });
+        expect(str === "Hi! My name is Slim Shady");
+    });
+
     it("is alphanumeric", () => {
         expect(utils.Strings.isAlphanumeric("313"));
         expect(!utils.Strings.isAlphanumeric("everybody in the 313"));


### PR DESCRIPTION
Was working on UV and thought this would make some of the templates easier to use/understand. Something to do while I wait for FOLIO to load all of our courses.

```js
let str = "{greeting} My name is {alias}";
str = utils.Strings.format(str, { alias: "Slim Shady", greeting: "Hi!" });
expect(str === "Hi! My name is Slim Shady");
```

- [ ] Some build steps aren't working (build:umd, build:var, build:docs). Probably my setup or my use of pnpm.
- [ ] Sorry about the empty line at the end of the files, I can fix that if you care.